### PR TITLE
Multi-file processor correctly passes results to the nested callback

### DIFF
--- a/es5/multi-file-processor.js
+++ b/es5/multi-file-processor.js
@@ -37,9 +37,9 @@ exports.default = function (inputPatterns, options, fileCallback, resultCallback
           return _spellcheck2.default.addWord(word, true);
         });
 
-        fileCallback(file, src, function () {
+        fileCallback(file, src, function (err, result) {
           _spellcheck2.default.resetTemporaryCustomDictionary();
-          fileProcessed();
+          fileProcessed(err, result);
         });
       });
     }, resultCallback);

--- a/es6/multi-file-processor.js
+++ b/es6/multi-file-processor.js
@@ -39,9 +39,9 @@ export default function(inputPatterns, options, fileCallback, resultCallback) {
           spellConfig.getFileWords(file)
             .forEach((word) => spellcheck.addWord(word, true));
 
-          fileCallback(file, src, () => {
+          fileCallback(file, src, (err, result) => {
             spellcheck.resetTemporaryCustomDictionary();
-            fileProcessed();
+            fileProcessed(err, result);
           });
         });
       }, resultCallback);


### PR DESCRIPTION
There was a bug introduced in c6924f9ceede98b5cc2735b00c6c1857dc42c8c6 where the callback invoked when each file was processed lost the error & result arguments.

Before this fix:

```
$ node bin/mdspell -ran *.md
    readme.md
        7 | asdasd 

>> 2 files are free from spelling errors
```

After the fix:

```
$ node bin/mdspell -ran *.md
    readme.md
        7 | asdasd 

>> 1 spelling error found in 2 files
```

I think this fixes #46 - which was raised after the bug was committed.
