### PR TITLE
add cyrillic word support on word parser

### DIFF
--- a/es5/cli-interactive.js
+++ b/es5/cli-interactive.js
@@ -91,7 +91,7 @@ function incorrectWordChoices(word, message, filename, options, done) {
     message: message,
     choices: choices,
     default: defaultAction
-  }], function (answer) {
+  }]).then(function (answer) {
     switch (answer.action) {
       case ACTION_ADD:
         word = word.toLowerCase();
@@ -132,7 +132,7 @@ function getCorrectWord(word, filename, options, done) {
     name: "word",
     message: "correct word >",
     default: word
-  }], function (answer) {
+  }]).then(function (answer) {
     var newWords = answer.word.split(/\s/g);
     var hasMistake = false;
 

--- a/es5/word-parser.js
+++ b/es5/word-parser.js
@@ -10,7 +10,7 @@ exports.default = function (tokens) {
     var index = token.index;
     while (true) {
       // eslint-disable-line no-constant-condition
-      var nextWord = text.match(/(\w+(\.\w+)+\.?)|[\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019][\-#\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019]*/);
+      var nextWord = text.match(/(\w+(\.\w+)+\.?)|[\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019][\-#\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019]*|[\u0400-\u04FF\w'\u2018-\u2019][\-#\u0400-\u04FF\w'\u2018-\u2019]*/);
       if (!nextWord) {
         break;
       }

--- a/es6/cli-interactive.js
+++ b/es6/cli-interactive.js
@@ -67,7 +67,7 @@ function incorrectWordChoices(word, message, filename, options, done) {
     message: message,
     choices,
     default: defaultAction
-  }], function(answer) {
+  }]).then(function(answer) {
     switch (answer.action) {
       case ACTION_ADD:
         word = word.toLowerCase();
@@ -108,7 +108,7 @@ function getCorrectWord(word, filename, options, done) {
     name: "word",
     message: "correct word >",
     default: word
-  }], function(answer) {
+  }]).then(function(answer) {
     const newWords = answer.word.split(/\s/g);
     let hasMistake = false;
 

--- a/es6/word-parser.js
+++ b/es6/word-parser.js
@@ -5,7 +5,7 @@ export default function(tokens) {
     let text = token.text;
     let index = token.index;
     while (true) { // eslint-disable-line no-constant-condition
-      const nextWord = text.match(/(\w+(\.\w+)+\.?)|[\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019][\-#\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019]*/);
+      const nextWord = text.match(/(\w+(\.\w+)+\.?)|[\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019][\-#\u00c0-\u01bf\u01d0-\u029f\w'\u2018-\u2019]*|[\u0400-\u04FF\w'\u2018-\u2019][\-#\u0400-\u04FF\w'\u2018-\u2019]*/);
       if (!nextWord) {
         break;
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "globby": "^4.0.0",
     "hunspell-spellchecker": "^1.0.2",
     "inquirer": "^1.0.0",
-    "marked": "^0.3.5"
+    "marked": "^0.3.5",
+    "sinon-as-promised": "^4.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.3.26",

--- a/test/word-parser.js
+++ b/test/word-parser.js
@@ -8,10 +8,22 @@ describe("word parser", () => {
     expect(words).to.deep.equal([ { word: 'word', index: 0 }]);
   });
 
+  it("should be able to find a cyrillic word", () => {
+    const words = wordParser([{ text: "монгол", index: 0 }]);
+
+    expect(words).to.deep.equal([ { word: 'монгол', index: 0 }]);
+  });
+
   it("should be able to find multiple words", () => {
     const words = wordParser([{ text: "a word", index: 0 }]);
 
     expect(words).to.deep.equal([ { word: 'a', index: 0 }, { word: 'word', index: 2 }]);
+  });
+
+  it("should be able to find multiple words from mixed string with latin & cyrillic", () => {
+    const words = wordParser([{ text: "Mongolia монгол", index: 0 }]);
+
+    expect(words).to.deep.equal([ { word: 'Mongolia', index: 0 }, { word: 'монгол', index: 9 }]);
   });
 
   it("should ignore punctuation", () => {


### PR DESCRIPTION
i would like to use this on cyrillic text but it doesn’t parse cyrillic words. 

So i implemented & added couple of test as well 

Also mentioned [here](https://github.com/lukeapage/node-markdown-spellcheck/pull/66#issuecomment-221540392) as well after upgraded inquirer to 1.0.0 cli interactive options quits just after first action. So updated prompt function on cli-interactive.js & updated tests as well

Thanks