### PR TITLE
Include the word index in the report output

### DIFF
--- a/es5/report-generator.js
+++ b/es5/report-generator.js
@@ -44,7 +44,8 @@ function generateFileReport(file, spellingInfo) {
 
     var lineNumber = String(displayBlock.lineNumber);
     var lineNumberPadding = Array(10 - lineNumber.length).join(' ');
-    var linePrefix = '' + lineNumberPadding + lineNumber + ' |';
+    var errorIndex = String(error.index);
+    var linePrefix = '' + lineNumberPadding + lineNumber + ':' + errorIndex + ' |';
     report += linePrefix + ' ' + displayBlock.info + ' \n';
   }
   return report;

--- a/es6/report-generator.js
+++ b/es6/report-generator.js
@@ -28,7 +28,8 @@ export function generateFileReport(file, spellingInfo) {
 
     const lineNumber = String(displayBlock.lineNumber);
     const lineNumberPadding = Array(10 - lineNumber.length).join(' ');
-    const linePrefix = `${lineNumberPadding}${lineNumber} |`;
+    const errorIndex = String(error.index);
+    const linePrefix = `${lineNumberPadding}${lineNumber}:${errorIndex} |`;
     report += `${linePrefix} ${displayBlock.info} \n`;
   }
   return report;


### PR DESCRIPTION
Hello there! 

I was adding support for a blog to show errors via [Danger](https://github.com/danger/danger) (https://github.com/artsy/artsy.github.io/pull/234) but when using without colour I couldn't get access to the word that needs changing.

_note_ this is my first PR to an NPM module, `npm run tests` passed, but I might be missing something.
