### PR TITLE
feat(pkg): add "module" field for es6 code

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">=0.10.0"
   },
   "main": "es5/index.js",
+  "module: "es6/index.js",
   "bin": {
     "mdspell": "./bin/mdspell"
   },


### PR DESCRIPTION
This pr adds a "module" field and specifies the path to the es6/index.js as the value. 

webpack 2+ can handle ECMAScript import and export statements out of the box with no additional transformations, and will look for a `module` field to load it from first over `main`. This PR adds the `module` field so that webpack can automatically pick up the ES6 version over the ES5.