### PR TITLE
Only ignore text between two h-rules if it looks like Jekyll front matter

### DIFF
--- a/es5/markdown-parser.js
+++ b/es5/markdown-parser.js
@@ -2,6 +2,8 @@
 
 exports.__esModule = true;
 
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 exports.default = function (src) {
   var textTokens = [];
   var currentIndex = 0;
@@ -10,7 +12,12 @@ exports.default = function (src) {
 
   // remove things we won't process so we can use simple next matching word logic
   // to calculate the index
-  tracker.replaceAll(/\---\r?\n[\w\W]*?\r?\n---/, " "); // remove header
+
+  var jekyllFrontMatter = getJekyllFrontMatter(src);
+  if (jekyllFrontMatter) {
+    tracker.replaceAll(jekyllFrontMatter, " ");
+  }
+
   tracker.removeAll(/```[\w\W]*?```/);
   tracker.removeAll(/~~~[\w\W]*?~~~/);
   tracker.removeAll(/``[\w\W]*?``/);
@@ -72,8 +79,28 @@ var _marked = require("marked");
 
 var _marked2 = _interopRequireDefault(_marked);
 
+var _jsYaml = require("js-yaml");
+
+var _jsYaml2 = _interopRequireDefault(_jsYaml);
+
 var _trackingReplacement = require("./tracking-replacement");
 
 var _trackingReplacement2 = _interopRequireDefault(_trackingReplacement);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function getJekyllFrontMatter(src) {
+  var matches = src.match(/^\r?\n?---\r?\n([\w\W]+)\r?\n---\r?\n/);
+
+  if (matches) {
+    var fencedContent = matches[1];
+
+    try {
+      var parsed = _jsYaml2.default.safeLoad(fencedContent);
+
+      return (typeof parsed === "undefined" ? "undefined" : _typeof(parsed)) === "object" ? matches[0] : undefined;
+    } catch (e) {
+      // not valid yaml
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "globby": "^6.1.0",
     "hunspell-spellchecker": "^1.0.2",
     "inquirer": "^1.0.0",
+    "js-yaml": "^3.10.0",
     "marked": "^0.3.5",
     "sinon-as-promised": "^4.0.0"
   },

--- a/test/markdown-parser.js
+++ b/test/markdown-parser.js
@@ -84,6 +84,49 @@ This is a \`var\` inline.
       {text: 'inline.', index: 17}]);
   });
 
+  it("should be able to ignore jekyll front matter", () => {
+    const tokens = markdownParser(`
+---
+title: Post title
+---
+Hello
+    `);
+
+    expect(tokens).to.deep.equal([
+      {text: 'Hello', index: 27}
+    ]);
+  });
+
+  it("doesn't ignore text between two horizontal rules at the beginning of the content", () => {
+    const tokens = markdownParser(`
+---
+Apple
+---
+Banana
+    `);
+
+    expect(tokens).to.deep.equal([
+      {text: 'Apple', index: 5},
+      {text: 'Banana', index: 15}
+    ]);
+  });
+
+  it("doesn't ignore text between two horizontal rules in the middle of the content", () => {
+    const tokens = markdownParser(`
+Apple
+---
+Banana
+---
+Orange
+    `);
+
+    expect(tokens).to.deep.equal([
+      {text: 'Apple', index: 1},
+      {text: 'Banana', index: 11},
+      {text: 'Orange', index: 22}
+    ]);
+  });
+
   it("should be able to cope with double back-tick", () => {
     const tokens = markdownParser(`
 This is a \`\`var\` with backtick\`\` inline.


### PR DESCRIPTION
This is an idea for fixing #98.

The regex is tweaked to only get the first pair of horizontal rules, and a YAML parser is used to decide if the content within looks like Jekyll [front matter](https://jekyllrb.com/docs/frontmatter/). From a replacement tracking perspective, it's still asking the tracker to replace a particular string with a single whitespace - so I think that should still work.

Doing this instead of having an on/off option for the original behaviour allows you both ignore front matter and spellcheck within other h-rule pairs (that use the minimal three-dash style) at the same time.

There are tests, and the existing ones still pass, but it would be good to try running this against some real content.

A future enhancement might allow specified fields of the front matter (e.g. title, summary) to be spell checked (a spelling mistake in a blog post summary is how I came to find this issue).