### PR TITLE
107 front matter regex

### DIFF
--- a/es5/markdown-parser.js
+++ b/es5/markdown-parser.js
@@ -90,7 +90,7 @@ var _trackingReplacement2 = _interopRequireDefault(_trackingReplacement);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function getJekyllFrontMatter(src) {
-  var matches = src.match(/^\r?\n?---\r?\n([\w\W]+)\r?\n---\r?\n/);
+  var matches = src.match(/^\r?\n?---\r?\n([\w\W]+?)\r?\n---\r?\n/);
 
   if (matches) {
     var fencedContent = matches[1];

--- a/es5/tracking-replacement.js
+++ b/es5/tracking-replacement.js
@@ -19,13 +19,24 @@ exports.default = function (src) {
     }
     return newIndex;
   }
-  function replaceAll(regex, replacement) {
+  function replaceAll(target, replacement) {
     while (true) {
       // eslint-disable-line no-constant-condition
-      var match = src.match(regex);
-      if (!match) {
+      var match = void 0;
+
+      if (target instanceof RegExp) {
+        match = src.match(target);
+      } else {
+        match = {
+          index: src.indexOf(target),
+          0: target
+        };
+      }
+
+      if (!match || match.index === -1) {
         break;
       }
+
       var cutTo = match.index + match[0].length;
       var originalIndex = getOriginalIndex(cutTo);
       var changeInLength = match[0].length - replacement.length;
@@ -52,8 +63,8 @@ exports.default = function (src) {
   }
 
   return {
-    removeAll: function removeAll(regex) {
-      return replaceAll(regex, "");
+    removeAll: function removeAll(target) {
+      return replaceAll(target, "");
     },
 
     replaceAll: replaceAll,

--- a/es6/markdown-parser.js
+++ b/es6/markdown-parser.js
@@ -81,7 +81,7 @@ export default function(src) {
 }
 
 function getJekyllFrontMatter(src) {
-  const matches = src.match(/^\r?\n?---\r?\n([\w\W]+)\r?\n---\r?\n/);
+  const matches = src.match(/^\r?\n?---\r?\n([\w\W]+?)\r?\n---\r?\n/);
 
   if (matches) {
     const fencedContent = matches[1];

--- a/es6/tracking-replacement.js
+++ b/es6/tracking-replacement.js
@@ -15,12 +15,23 @@ export default function(src) {
     }
     return newIndex;
   }
-  function replaceAll(regex, replacement) {
+  function replaceAll(target, replacement) {
     while (true) { // eslint-disable-line no-constant-condition
-      const match = src.match(regex);
-      if (!match) {
+      let match;
+
+      if (target instanceof RegExp) {
+        match = src.match(target);
+      } else {
+        match = {
+          index: src.indexOf(target),
+          0: target
+        };
+      }
+
+      if (!match || match.index === -1) {
         break;
       }
+
       const cutTo = match.index + match[0].length;
       const originalIndex = getOriginalIndex(cutTo);
       const changeInLength = match[0].length - replacement.length;
@@ -48,8 +59,8 @@ export default function(src) {
   }
 
   return {
-    removeAll(regex) {
-      return replaceAll(regex, "");
+    removeAll(target) {
+      return replaceAll(target, "");
     },
     replaceAll,
     getOriginalIndex

--- a/test/markdown-parser.js
+++ b/test/markdown-parser.js
@@ -127,6 +127,22 @@ Orange
     ]);
   });
 
+  it("doesn't ignore text between jekyll front matter and a horizontal rule in the content", () => {
+    const tokens = markdownParser(`
+---
+author: test
+---
+This should be spell checked
+---
+`);
+    expect(tokens).to.deep.equal([ 
+      { text: 'This', index: 22 },
+      { text: 'should', index: 27 },
+      { text: 'be', index: 34 },
+      { text: 'spell', index: 37 },
+      { text: 'checked', index: 43 }]);
+  });
+
   it("should be able to cope with double back-tick", () => {
     const tokens = markdownParser(`
 This is a \`\`var\` with backtick\`\` inline.

--- a/test/tracking-replacement.js
+++ b/test/tracking-replacement.js
@@ -59,4 +59,25 @@ describe("tracking replacement", () => {
     expect(replacer.getOriginalIndex(3)).to.equal(6);
   });
 
+  it("tracks a single replaceAll with string not regex", () => {
+    const frontMatter = "---author:tester---";
+    const replacer = trackingReplacement(`${frontMatter} content`);
+    const replaced = replacer.removeAll(frontMatter);
+    expect(replaced).to.equal(" content");
+    expect(replacer.getOriginalIndex(2)).to.equal(21);
+    expect(replacer.getOriginalIndex(3)).to.equal(22); 
+  });
+
+  it("tracks a single replaceAll when target string contains regex", () => {
+    const frontMatter = `
+    ---
+    author: tester
+    summary: "In my last article (on line annotation components for D3 charts)"
+    ---`;
+    const replacer = trackingReplacement(`${frontMatter} content`);
+    const replaced = replacer.removeAll(frontMatter);
+    expect(replaced).to.equal(" content");
+    expect(replacer.getOriginalIndex(2)).to.equal(117);
+  });
+
 });


### PR DESCRIPTION
Closes #107

This branch aims to fix two issues:
The Markdown-Parser was using regex that was 'greedy' meaning that it would match the start of the front matter to the last --- found, this was causing issues when the content of the file had horizontal lines. To fix this, the regex was changed to be lazy by adding a ? rule meaning that it would stop matching at the next available --- (the end of front matter).

The Tracking Replacement was modified to take a string as a parameter as well as regex. Previously, when passing a string to the replacer that contained regex characters, the matching method recognized it as regex and incorrectly matched it. This has now been changed to check if the input is a string or not, if it is then we mock the matched result and continue with the replacement.