### PR TITLE
Release Version 1.3.1

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -13,8 +13,11 @@ v1.0.0
 v1.1.0
 v1.2.0
 v1.3.0
+v1.3.1
 Kramdown
 v0.10.0
 v0.11.0
 cryllic
 index.js
+rereleased
+unix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v1.3.1
+
+21-11-2017
+
+* Rereleased the package with unix lines endings (LF)
+
 v1.3.0
 
 15-11-2017

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-spellcheck",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Spell-checks markdown files with an interactive CLI allowing automated spell checking.",
   "keywords": [
     "markdown",


### PR DESCRIPTION
Changed the file line endings in the npm package published to be LF from
CRLF. This was causing some issues when trying to run mdspell from Unix
machines.