### PR TITLE
Add no color option

### DIFF
--- a/es5/cli.js
+++ b/es5/cli.js
@@ -46,7 +46,19 @@ var buildVersion = JSON.parse(packageConfig).version;
 _commander2.default.version(buildVersion)
 // default cli behaviour will be an interactive walkthrough each error, with suggestions,
 // options to replace etc.
-.option('-r, --report', 'Outputs a full report which details the unique spelling errors found.').option('-n, --ignore-numbers', 'Ignores numbers.').option('--en-us', 'American English dictionary.').option('--en-gb', 'British English dictionary.').option('--en-au', 'Australian English dictionary.').option('--es-es', 'Spanish dictionary.').option('-d, --dictionary [file]', 'specify a custom dictionary file - it should not include the file extension and will load .dic and .aiff.').option('-a, --ignore-acronyms', 'Ignores acronyms.').option('-x, --no-suggestions', 'Do not suggest words (can be slow)').option('-t, --target-relative', 'Uses ".spelling" files relative to the target.').usage("[options] source-file source-file").parse(process.argv);
+  .option('-r, --report', 'Outputs a full report which details the unique spelling errors found')
+  .option('-n, --ignore-numbers', 'Ignores numbers')
+  .option('--en-us', 'American English dictionary')
+  .option('--en-gb', 'British English dictionary')
+  .option('--en-au', 'Australian English dictionary')
+  .option('--es-es', 'Spanish dictionary')
+  .option('-d, --dictionary [file]', 'Specify a custom dictionary file - it should not include the file extension and will load .dic and .aiff')
+  .option('-a, --ignore-acronyms', 'Ignores acronyms')
+  .option('-x, --no-suggestions', 'Do not suggest words (can be slow)')
+  .option('-t, --target-relative', 'Uses ".spelling" files relative to the target')
+  .option('-z, --no-color','No color output in report')
+  .usage("[options] source-file source-file").parse(process.argv)
+;
 
 var language = void 0;
 if (_commander2.default.enUs) {
@@ -59,16 +71,22 @@ if (_commander2.default.enUs) {
   language = "es-es";
 }
 
+
 var options = {
   ignoreAcronyms: _commander2.default.ignoreAcronyms,
   ignoreNumbers: _commander2.default.ignoreNumbers,
   suggestions: _commander2.default.suggestions,
   relativeSpellingFiles: _commander2.default.targetRelative,
+  color: _commander2.default.color,
   dictionary: {
     language: language,
     file: _commander2.default.dictionary
   }
 };
+
+if ( ! options.color ) {
+  _chalk2.default.enabled = false;
+}
 
 if (!_commander2.default.args.length) {
   _commander2.default.outputHelp();
@@ -84,7 +102,7 @@ if (!_commander2.default.args.length) {
     if (_commander2.default.report) {
       var errors = _index2.default.spell(src, options);
       if (errors.length > 0) {
-        console.log((0, _reportGenerator.generateFileReport)(filename, { errors: errors, src: src }));
+        console.log((0, _reportGenerator.generateFileReport)(filename, { errors: errors, src: src }, options));
         process.exitCode = 1;
       }
       fileProcessed(null, errors);

--- a/es5/context.js
+++ b/es5/context.js
@@ -66,7 +66,7 @@ function getLines(src, index, noBefore, noAfter) {
 }
 
 exports.default = {
-  getBlock: function getBlock(src, index, length) {
+  getBlock: function getBlock(src, index, length, options) {
     var lineInfo = getLines(src, index, 2, 2);
     var lineStart = 0;
     var lineEnd = lineInfo.line.length;
@@ -76,7 +76,13 @@ exports.default = {
     if (lineEnd - (lineInfo.column + length) > 30) {
       lineEnd = lineInfo.column + length + 30;
     }
-    var info = lineInfo.line.substring(lineStart, lineInfo.column) + _chalk2.default.red(lineInfo.line.substr(lineInfo.column, length)) + lineInfo.line.substring(lineInfo.column + length, lineEnd);
+
+    var info =  lineInfo.line.substring(lineStart, lineInfo.column) +
+                ( options.color ? "" : "[[[") +
+                _chalk2.default.red(lineInfo.line.substr(lineInfo.column, length)) +
+                ( options.color ? "" : "]]]") +
+                lineInfo.line.substring(lineInfo.column + length, lineEnd);
+
     return {
       info: info,
       lineNumber: lineInfo.lineNumber

--- a/es5/report-generator.js
+++ b/es5/report-generator.js
@@ -35,12 +35,12 @@ function generateSummaryReport(results) {
 }
 
 // Generates a report for the errors found in a single markdown file.
-function generateFileReport(file, spellingInfo) {
+function generateFileReport(file, spellingInfo, options) {
   var report = '    ' + _chalk2.default.bold(file) + '\n';
 
   for (var k = 0; k < spellingInfo.errors.length; k++) {
     var error = spellingInfo.errors[k];
-    var displayBlock = _context2.default.getBlock(spellingInfo.src, error.index, error.word.length);
+    var displayBlock = _context2.default.getBlock(spellingInfo.src, error.index, error.word.length, options);
 
     var lineNumber = String(displayBlock.lineNumber);
     var lineNumberPadding = Array(10 - lineNumber.length).join(' ');

--- a/readme.md
+++ b/readme.md
@@ -84,12 +84,12 @@ Where `speling` will be highlighted in red.
  * "Add to file ignores" will ignore the word in this file only.
  * "Add to dictionary - case insensitive" will add to the dictionary for all files and match any case. E.g. with the word `Microsoft` both `Microsoft` and `microsoft` would match.
  * "Add to dictionary - case sensitive" will add to the dictionary for all files and match the case that has been used. E.g. with the word `Microsoft`, the word `microsoft` will not match.
- 
+
 All exclusions will be stored in a `.spelling` file in the directory from which you run the command.
 
 ### Target Relative Mode
 
-Using the `--target-relative` (`-t`) option will augment the shared `.spelling` file with a relative `.spelling` file (sibling of the `.md` file) and give you the additional options with the interactive mode: 
+Using the `--target-relative` (`-t`) option will augment the shared `.spelling` file with a relative `.spelling` file (sibling of the `.md` file) and give you the additional options with the interactive mode:
 
 * "Add to file ignores" will be replaced with "[Relative] Add to file ignores". There is no need to add file ignores into the shared `.spelling` file.
 * "[Relative] Add to dictionary - case insensitive" will add to the dictionary for all files within the current `.md` file and match any case.
@@ -97,7 +97,12 @@ Using the `--target-relative` (`-t`) option will augment the shared `.spelling` 
 
 ### Report Mode
 
-Using the `--report` (`-r`) option will show a report of all the spelling mistakes that have been found. This mode is useful for CI build reports. 
+Using the `--report` (`-r`) option will show a report of all the spelling mistakes that have been found. This mode is useful for CI build reports.
+
+### No Color Mode
+
+For situations where the report colors do not show up and you can't identify the failing words, the `--no-color` (`-z`) will turn off color and surround the spelling mistakes with square brackets, such as `[[[mistaek]]]`.
+
 
 ## `.spelling` files
 


### PR DESCRIPTION
Fixes #36.  This is an attempt to add the command line parameter to support no color mode.

* Added -z / --no-color.
* Re-aligned the command line options code to make it easier to edit.
* Disabled color via _chalk, and added square brackets around spelling mistakes, such as: `[[[mistaeks]]]`.
* Updated README.md

Two outstanding questions for feedback:
1.  Couldn't decide on the best single letter for the parameter, so I went with -z.  -c seemed more like it would ENABLE color, not disable it.  Happy for feedback to adjust it.  Could possibly simply use --no-color and no single letter if preferred?
2. I thought the triple square brackets worked, but open to other's opinions?

I couldn't find any CONTRIBUTING guidelines, so I am simply submitting straight into `master`. Hope that's ok!