### PR TITLE
Update ignore numbers flag to ignore any token containing numbers

### DIFF
--- a/es6/filters.js
+++ b/es6/filters.js
@@ -3,7 +3,7 @@ function filterFactory(regexp) {
     errors.filter((e) => !e.word.match(regexp));
 }
 
-const numbers = filterFactory(/^[0-9,\.\-#]+(th|st|nd|rd)?$/);
+const numbers = filterFactory(/^[\w\W]*[0-9,\.\-#]+[\w\W]*$/);
 const acronyms = filterFactory(/^[A-Z0-9]{2,}(['\u2018-\u2019]s)?$/);
 
 export default {


### PR DESCRIPTION
This is useful in cases like mine where I was linting files containing short form links to github repos (eg. `vapor/vapor#255`) which would not be ignored with `--ignore-numbers`