### PR TITLE
Normalizes path strings for file dictionary

### DIFF
--- a/es5/spell-config.js
+++ b/es5/spell-config.js
@@ -10,6 +10,10 @@ var _async = require('async');
 
 var _async2 = _interopRequireDefault(_async);
 
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var globalDictionary = [];
@@ -134,16 +138,18 @@ function addToGlobalDictionary(word, relative) {
   spelling.isDirty = true;
   spelling.lastLineOfGlobalSpellings++;
   for (var filename in fileDictionary) {
-    if (fileDictionary.hasOwnProperty(filename)) {
-      fileDictionary[filename].index++;
+    var normalizedPath = _path2.default.normalize(filename);
+    if (fileDictionary.hasOwnProperty(normalizedPath)) {
+      fileDictionary[normalizedPath].index++;
     }
   }
 }
 
 function addToFileDictionary(filename, word, relative) {
+  var normalizedPath = _path2.default.normalize(filename);
   var spelling = relative ? relativeSpelling : sharedSpelling;
-  if (fileDictionary.hasOwnProperty(filename)) {
-    var fileDict = fileDictionary[filename];
+  if (fileDictionary.hasOwnProperty(normalizedPath)) {
+    var fileDict = fileDictionary[normalizedPath];
     spelling.fileLines.splice(fileDict.index, 0, word);
     spelling.isDirty = true;
     for (var dictionaryFilename in fileDictionary) {
@@ -153,9 +159,9 @@ function addToFileDictionary(filename, word, relative) {
     }
     fileDict.words.push(word);
   } else {
-    spelling.fileLines.splice(spelling.fileLines.length - 1, 0, " - " + filename, word);
+    spelling.fileLines.splice(spelling.fileLines.length - 1, 0, " - " + normalizedPath, word);
     spelling.isDirty = true;
-    fileDictionary[filename] = {
+    fileDictionary[normalizedPath] = {
       index: spelling.fileLines.length - 1,
       words: [word]
     };
@@ -167,8 +173,9 @@ function getGlobalWords() {
 }
 
 function getFileWords(filename) {
-  if (fileDictionary.hasOwnProperty(filename)) {
-    return fileDictionary[filename].words;
+  var normalizedPath = _path2.default.normalize(filename);
+  if (fileDictionary.hasOwnProperty(normalizedPath)) {
+    return fileDictionary[normalizedPath].words;
   }
   return [];
 }

--- a/es6/spell-config.js
+++ b/es6/spell-config.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import async from 'async';
+import path from 'path';
 
 let globalDictionary = [];
 let fileDictionary = {};
@@ -133,16 +134,18 @@ function addToGlobalDictionary(word, relative) {
   spelling.isDirty = true;
   spelling.lastLineOfGlobalSpellings++;
   for (let filename in fileDictionary) {
-    if (fileDictionary.hasOwnProperty(filename)) {
-      fileDictionary[filename].index++;
+    const normalizedPath = path.normalize(filename)
+    if (fileDictionary.hasOwnProperty(normalizedPath)) {
+      fileDictionary[normalizedPath].index++;
     }
   }
 }
 
 function addToFileDictionary(filename, word, relative) {
+  const normalizedPath = path.normalize(filename)
   const spelling = relative ? relativeSpelling : sharedSpelling;
-  if (fileDictionary.hasOwnProperty(filename)) {
-    let fileDict = fileDictionary[filename];
+  if (fileDictionary.hasOwnProperty(normalizedPath)) {
+    let fileDict = fileDictionary[normalizedPath];
     spelling.fileLines.splice(fileDict.index, 0, word);
     spelling.isDirty = true;
     for (let dictionaryFilename in fileDictionary) {
@@ -154,9 +157,9 @@ function addToFileDictionary(filename, word, relative) {
     fileDict.words.push(word);
   }
   else {
-    spelling.fileLines.splice(spelling.fileLines.length - 1, 0, " - " + filename, word);
+    spelling.fileLines.splice(spelling.fileLines.length - 1, 0, " - " + normalizedPath, word);
     spelling.isDirty = true;
-    fileDictionary[filename] = {
+    fileDictionary[normalizedPath] = {
       index: spelling.fileLines.length - 1,
       words: [word]
     };
@@ -168,8 +171,9 @@ function getGlobalWords() {
 }
 
 function getFileWords(filename) {
-  if (fileDictionary.hasOwnProperty(filename)) {
-    return fileDictionary[filename].words;
+  const normalizedPath = path.normalize(filename)
+  if (fileDictionary.hasOwnProperty(normalizedPath)) {
+    return fileDictionary[normalizedPath].words;
   }
   return [];
 }

--- a/test/spell-config.js
+++ b/test/spell-config.js
@@ -51,6 +51,17 @@ describe("Spell-Config", () => {
     expect(initDone.calledOnce).to.equal(true);
   });
 
+  it("should match path regardless of dot slash", () => {
+    const FILE1 = "relative/blog.md";
+    const FILE2 = "./" + FILE1;
+    const initDone = sinon.stub();
+    const spellConfig = getSpellConfig();
+    spellConfig.initialise("./.spelling", initDone);
+    spellConfig.addToFileDictionary(FILE1, "aaaaa", false);
+    expect(spellConfig.getFileWords(FILE2).length).to.equal(1);
+    expect(initDone.calledOnce).to.equal(true);
+  });
+
   it("should add file words from relative or shared into array", () => {
     const FILE = "/relative/blog.md";
     const initDone = sinon.stub();


### PR DESCRIPTION
This PR leverages [path.normalize](https://nodejs.org/api/path.html#path_path_normalize_path) to ensure that `./filename` and `filename` are mapped to the same entry in the file dictionary. Also similarly matches `dir/subdir/../file` and `dir/file`.