### PR TITLE
Bump marked version to fix vulnerability

### DIFF
--- a/es5/markdown-parser.js
+++ b/es5/markdown-parser.js
@@ -1,19 +1,45 @@
-"use strict";
-
 exports.__esModule = true;
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+let _marked = require("marked");
+
+let _marked2 = _interopRequireDefault(_marked);
+
+let _jsYaml = require("js-yaml");
+
+let _jsYaml2 = _interopRequireDefault(_jsYaml);
+
+let _trackingReplacement = require("./tracking-replacement");
+
+let _trackingReplacement2 = _interopRequireDefault(_trackingReplacement);
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
+
+let _typeof =
+  typeof Symbol === "function" && typeof Symbol.iterator === "symbol"
+    ? function (obj) {
+        return typeof obj;
+      }
+    : function (obj) {
+        return obj &&
+          typeof Symbol === "function" &&
+          obj.constructor === Symbol &&
+          obj !== Symbol.prototype
+          ? "symbol"
+          : typeof obj;
+      };
 
 exports.default = function (src) {
-  var textTokens = [];
-  var currentIndex = 0;
+  let textTokens = [];
+  let currentIndex = 0;
 
-  var tracker = (0, _trackingReplacement2.default)(src);
+  let tracker = (0, _trackingReplacement2.default)(src);
 
   // remove things we won't process so we can use simple next matching word logic
   // to calculate the index
 
-  var jekyllFrontMatter = getJekyllFrontMatter(src);
+  let jekyllFrontMatter = getJekyllFrontMatter(src);
   if (jekyllFrontMatter) {
     tracker.replaceAll(jekyllFrontMatter, " ");
   }
@@ -30,7 +56,7 @@ exports.default = function (src) {
   tracker.replaceAll(/&[#a-z0-9]{1,5};/, " ");
   src = tracker.replaceAll(/<\/?[a-z0-9]+ ?([a-z]+="[^"]*" ?)*\/?>/i, " ");
 
-  var options = {
+  let options = {
     gfm: true,
     renderer: {
       strong: function strong() {},
@@ -42,9 +68,11 @@ exports.default = function (src) {
       image: function image() {},
       text: function text(_text) {
         _text = _text.replace(/&#39;/g, "'");
-        var roughSplit = _text.split(/(https?|ftp):\/\/[^\s/$.?#].[^\s]*|[\s\xa0\r\n]|&[a-z#0-9]+;|[&<>]/);
-        for (var i = 0; i < roughSplit.length; i++) {
-          var split = roughSplit[i];
+        let roughSplit = _text.split(
+          /(https?|ftp):\/\/[^\s/$.?#].[^\s]*|[\s\xa0\r\n]|&[a-z#0-9]+;|[&<>]/
+        );
+        for (let i = 0; i < roughSplit.length; i++) {
+          let split = roughSplit[i];
           if (split) {
             addToken(split);
           }
@@ -54,19 +82,25 @@ exports.default = function (src) {
   };
 
   function addToken(text) {
-    var newIndex = src.indexOf(text, currentIndex);
+    let newIndex = src.indexOf(text, currentIndex);
     if (newIndex === -1) {
-      throw new Error("Markdown Parser : Inline Lexer : Could not find index of text - \n" + text + "\n\n**In**\n\n" + src.substring(currentIndex, 30) + "\n");
+      throw new Error(
+        "Markdown Parser : Inline Lexer : Could not find index of text - \n" +
+          text +
+          "\n\n**In**\n\n" +
+          src.substring(currentIndex, 30) +
+          "\n"
+      );
     }
     currentIndex = newIndex + text.length;
     textTokens.push({ text: text, index: tracker.getOriginalIndex(newIndex) });
   }
 
-  var tokens = _marked2.default.lexer(src, options);
-  var inlineLexer = new _marked2.default.InlineLexer(tokens.links, options);
+  let tokens = _marked2.default.lexer(src, options);
+  let inlineLexer = new _marked2.default.InlineLexer(tokens.links, options);
 
-  for (var i = 0; i < tokens.length; i++) {
-    var token = tokens[i];
+  for (let i = 0; i < tokens.length; i++) {
+    let token = tokens[i];
     if (token.text && token.type !== "code") {
       inlineLexer.output(token.text);
     }
@@ -75,30 +109,19 @@ exports.default = function (src) {
   return textTokens;
 };
 
-var _marked = require("marked");
-
-var _marked2 = _interopRequireDefault(_marked);
-
-var _jsYaml = require("js-yaml");
-
-var _jsYaml2 = _interopRequireDefault(_jsYaml);
-
-var _trackingReplacement = require("./tracking-replacement");
-
-var _trackingReplacement2 = _interopRequireDefault(_trackingReplacement);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 function getJekyllFrontMatter(src) {
-  var matches = src.match(/^\r?\n?---\r?\n([\w\W]+?)\r?\n---\r?\n/);
+  let matches = src.match(/^\r?\n?---\r?\n([\w\W]+?)\r?\n---\r?\n/);
 
   if (matches) {
-    var fencedContent = matches[1];
+    let fencedContent = matches[1];
 
     try {
-      var parsed = _jsYaml2.default.safeLoad(fencedContent);
+      let parsed = _jsYaml2.default.safeLoad(fencedContent);
 
-      return (typeof parsed === "undefined" ? "undefined" : _typeof(parsed)) === "object" ? matches[0] : undefined;
+      return (typeof parsed === "undefined" ? "undefined" : _typeof(parsed)) ===
+        "object"
+        ? matches[0]
+        : undefined;
     } catch (e) {
       // not valid yaml
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-spellcheck",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.1",
   "description": "Spell-checks markdown files with an interactive CLI allowing automated spell checking.",
   "keywords": [
     "markdown",
@@ -37,7 +37,7 @@
     "hunspell-spellchecker": "^1.0.2",
     "inquirer": "^1.0.0",
     "js-yaml": "^3.10.0",
-    "marked": "^0.7.0",
+    "marked": "^2.0.3",
     "sinon-as-promised": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Add a fix by bumping the `marked` package to version 2.0.0. 

This is to fix a vulnerability with that imported library.

Also rearrange `markdown-parser.js` to remove import ordering error 